### PR TITLE
Persist addresses when creating patient

### DIFF
--- a/his-patient-service/src/main/java/de/his/patient/application/dto/CreatePatientRequest.java
+++ b/his-patient-service/src/main/java/de/his/patient/application/dto/CreatePatientRequest.java
@@ -63,6 +63,10 @@ public class CreatePatientRequest {
     @Schema(description = "Consent for data processing", example = "true")
     private Boolean consentDataProcessing;
 
+    @Valid
+    @Schema(description = "List of patient addresses")
+    private List<CreateAddressRequest> addresses;
+
     public CreatePatientRequest() {}
 
     // Getters and Setters
@@ -107,4 +111,7 @@ public class CreatePatientRequest {
 
     public Boolean getConsentDataProcessing() { return consentDataProcessing; }
     public void setConsentDataProcessing(Boolean consentDataProcessing) { this.consentDataProcessing = consentDataProcessing; }
+
+    public List<CreateAddressRequest> getAddresses() { return addresses; }
+    public void setAddresses(List<CreateAddressRequest> addresses) { this.addresses = addresses; }
 }

--- a/his-patient-service/src/main/java/de/his/patient/application/dto/PatientResponse.java
+++ b/his-patient-service/src/main/java/de/his/patient/application/dto/PatientResponse.java
@@ -61,6 +61,9 @@ public class PatientResponse {
     @Schema(description = "Consent for data processing")
     private Boolean consentDataProcessing;
 
+    @Schema(description = "List of patient addresses")
+    private List<AddressResponse> addresses;
+
     @Schema(description = "Creation timestamp")
     private LocalDateTime createdAt;
 
@@ -75,6 +78,7 @@ public class PatientResponse {
                           InsuranceType insuranceType, String insuranceCompanyId,
                           String insuranceCompanyName, String phone, String email,
                           Boolean consentCommunication, Boolean consentDataProcessing,
+                          List<AddressResponse> addresses,
                           LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.firstName = firstName;
@@ -92,6 +96,7 @@ public class PatientResponse {
         this.email = email;
         this.consentCommunication = consentCommunication;
         this.consentDataProcessing = consentDataProcessing;
+        this.addresses = addresses;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
@@ -144,6 +149,9 @@ public class PatientResponse {
 
     public Boolean getConsentDataProcessing() { return consentDataProcessing; }
     public void setConsentDataProcessing(Boolean consentDataProcessing) { this.consentDataProcessing = consentDataProcessing; }
+
+    public List<AddressResponse> getAddresses() { return addresses; }
+    public void setAddresses(List<AddressResponse> addresses) { this.addresses = addresses; }
 
     public LocalDateTime getCreatedAt() { return createdAt; }
     public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }

--- a/his-patient-service/src/main/java/de/his/patient/domain/model/AddressType.java
+++ b/his-patient-service/src/main/java/de/his/patient/domain/model/AddressType.java
@@ -1,6 +1,7 @@
 package de.his.patient.domain.model;
 
 public enum AddressType {
+    PRIMARY,
     HOME,
     WORK,
     POSTAL,

--- a/his-patient-service/src/main/java/de/his/patient/domain/repository/AddressRepository.java
+++ b/his-patient-service/src/main/java/de/his/patient/domain/repository/AddressRepository.java
@@ -1,0 +1,11 @@
+package de.his.patient.domain.repository;
+
+import de.his.patient.domain.model.Address;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface AddressRepository extends JpaRepository<Address, UUID> {
+}


### PR DESCRIPTION
## Summary
- allow address type `PRIMARY`
- expose addresses on patient request and response DTOs
- persist and return patient addresses during patient creation
- save address entities through dedicated repository

## Testing
- `mvn -q -f his-patient-service/pom.xml test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4debfefb08324be55ecb0cc2723bc