### PR TITLE
Log address count before persisting patient addresses

### DIFF
--- a/his-patient-service/src/main/java/de/his/patient/application/service/PatientService.java
+++ b/his-patient-service/src/main/java/de/his/patient/application/service/PatientService.java
@@ -75,9 +75,11 @@ public class PatientService {
         }
 
         patient = patientRepository.save(patient);
-        if (!patient.getAddresses().isEmpty()) {
-            patient.getAddresses().forEach(address -> address.setPerson(patient));
-            addressRepository.saveAll(patient.getAddresses());
+        List<Address> addresses = patient.getAddresses();
+        if (!addresses.isEmpty()) {
+            addresses.forEach(address -> address.setPerson(patient));
+            logger.debug("Saving {} addresses", addresses.size());
+            addressRepository.saveAll(addresses);
         }
         
         logger.info("Created patient {} with KVNR {}", patient.getId(), request.getKvnr());


### PR DESCRIPTION
## Summary
- log number of addresses before saving them in PatientService

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network unreachable)*
- `./mvnw -q spring-boot:run -Dspring-boot.run.arguments="--logging.level.org.hibernate.SQL=DEBUG --logging.level.org.hibernate.type.descriptor.sql=TRACE"` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f5203cd8832498d1b9498fc59081