### PR TITLE
Align encounter service tests with shared Postgres setup

### DIFF
--- a/his-encounter-service/pom.xml
+++ b/his-encounter-service/pom.xml
@@ -21,7 +21,6 @@
         <java.version>21</java.version>
         <spring-cloud.version>2023.0.1</spring-cloud.version>
         <flyway.version>10.17.2</flyway.version>
-        <testcontainers.version>1.19.3</testcontainers.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -74,13 +73,6 @@
             <version>${flyway.version}</version>
         </dependency>
 
-        <!-- In-Memory DB für Tests -->
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-
         <!-- JSON Processing -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -106,7 +98,7 @@
             <artifactId>spring-cloud-starter-loadbalancer</artifactId>
         </dependency>
 
-        <!-- Test Dependencies - ✅ KORRIGIERTE SCOPES -->
+        <!-- Test Dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -118,18 +110,6 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <dependencyManagement>
@@ -138,13 +118,6 @@
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
                 <version>${spring-cloud.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-bom</artifactId>
-                <version>${testcontainers.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/his-encounter-service/src/main/java/de/his/encounter/domain/model/Encounter.java
+++ b/his-encounter-service/src/main/java/de/his/encounter/domain/model/Encounter.java
@@ -11,11 +11,15 @@ import java.util.List;
 import java.util.UUID;
 
 @Entity
-@Table(name = "encounters", indexes = {
-        @Index(name = "idx_patient_date", columnList = "patient_id, encounter_date"),
-        @Index(name = "idx_encounter_date", columnList = "encounter_date"),
-        @Index(name = "idx_status", columnList = "status")
-})
+@Table(
+        name = "encounters",
+        schema = "his_encounter",
+        indexes = {
+                @Index(name = "idx_patient_date", columnList = "patient_id, encounter_date"),
+                @Index(name = "idx_encounter_date", columnList = "encounter_date"),
+                @Index(name = "idx_status", columnList = "status")
+        }
+)
 public class Encounter {
 
     @Id

--- a/his-encounter-service/src/main/java/de/his/encounter/domain/model/EncounterDocumentation.java
+++ b/his-encounter-service/src/main/java/de/his/encounter/domain/model/EncounterDocumentation.java
@@ -10,10 +10,14 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
-@Table(name = "encounter_documentation", indexes = {
-        @Index(name = "idx_encounter_soap", columnList = "encounter_id, soap_section"),
-        @Index(name = "idx_author_date", columnList = "author_id, created_at")
-})
+@Table(
+        name = "encounter_documentation",
+        schema = "his_encounter",
+        indexes = {
+                @Index(name = "idx_encounter_soap", columnList = "encounter_id, soap_section"),
+                @Index(name = "idx_author_date", columnList = "author_id, created_at")
+        }
+)
 public class EncounterDocumentation {
 
     @Id

--- a/his-encounter-service/src/main/resources/db/migration/V1__Create_encounter_schema.sql
+++ b/his-encounter-service/src/main/resources/db/migration/V1__Create_encounter_schema.sql
@@ -3,3 +3,4 @@ CREATE SCHEMA IF NOT EXISTS his_encounter;
 
 -- Extension for UUID generation
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+

--- a/his-encounter-service/src/main/resources/db/migration/V2__Create_encounters_table.sql
+++ b/his-encounter-service/src/main/resources/db/migration/V2__Create_encounters_table.sql
@@ -1,4 +1,4 @@
-CREATE TABLE encounters (
+CREATE TABLE his_encounter.encounters (
     encounter_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     patient_id UUID NOT NULL,
     practitioner_id UUID NOT NULL,
@@ -12,13 +12,13 @@ CREATE TABLE encounters (
 );
 
 -- Indizes für Performance
-CREATE INDEX idx_encounters_patient_date ON encounters(patient_id, encounter_date DESC);
-CREATE INDEX idx_encounters_practitioner ON encounters(practitioner_id);
-CREATE INDEX idx_encounters_status ON encounters(status);
-CREATE INDEX idx_encounters_date ON encounters(encounter_date);
+CREATE INDEX idx_encounters_patient_date ON his_encounter.encounters(patient_id, encounter_date DESC);
+CREATE INDEX idx_encounters_practitioner ON his_encounter.encounters(practitioner_id);
+CREATE INDEX idx_encounters_status ON his_encounter.encounters(status);
+CREATE INDEX idx_encounters_date ON his_encounter.encounters(encounter_date);
 
 -- Trigger für updated_at
-CREATE OR REPLACE FUNCTION update_updated_at_column()
+CREATE OR REPLACE FUNCTION his_encounter.update_updated_at_column()
 RETURNS TRIGGER AS $$
 BEGIN
     NEW.updated_at = CURRENT_TIMESTAMP;
@@ -27,5 +27,5 @@ END;
 $$ LANGUAGE plpgsql;
 
 CREATE TRIGGER update_encounters_updated_at
-    BEFORE UPDATE ON encounters
-    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    BEFORE UPDATE ON his_encounter.encounters
+    FOR EACH ROW EXECUTE FUNCTION his_encounter.update_updated_at_column();

--- a/his-encounter-service/src/main/resources/db/migration/V3__Create_encounter_documentation_table.sql
+++ b/his-encounter-service/src/main/resources/db/migration/V3__Create_encounter_documentation_table.sql
@@ -1,6 +1,6 @@
-CREATE TABLE encounter_documentation (
+CREATE TABLE his_encounter.encounter_documentation (
     documentation_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    encounter_id UUID NOT NULL REFERENCES encounters(encounter_id) ON DELETE CASCADE,
+    encounter_id UUID NOT NULL REFERENCES his_encounter.encounters(encounter_id) ON DELETE CASCADE,
     soap_section VARCHAR(50) NOT NULL,
     content_type VARCHAR(50) NOT NULL,
     content TEXT,
@@ -10,11 +10,11 @@ CREATE TABLE encounter_documentation (
 );
 
 -- Indizes für SOAP-Dokumentation
-CREATE INDEX idx_documentation_encounter ON encounter_documentation(encounter_id);
-CREATE INDEX idx_documentation_soap_section ON encounter_documentation(encounter_id, soap_section);
-CREATE INDEX idx_documentation_author ON encounter_documentation(author_id);
-CREATE INDEX idx_documentation_date ON encounter_documentation(created_at);
+CREATE INDEX idx_documentation_encounter ON his_encounter.encounter_documentation(encounter_id);
+CREATE INDEX idx_documentation_soap_section ON his_encounter.encounter_documentation(encounter_id, soap_section);
+CREATE INDEX idx_documentation_author ON his_encounter.encounter_documentation(author_id);
+CREATE INDEX idx_documentation_date ON his_encounter.encounter_documentation(created_at);
 
 -- JSONB Index für strukturierte Suchen
-CREATE INDEX idx_documentation_structured_content ON encounter_documentation 
+CREATE INDEX idx_documentation_structured_content ON his_encounter.encounter_documentation
     USING GIN (structured_content);

--- a/his-encounter-service/src/test/resources/application-test.yml
+++ b/his-encounter-service/src/test/resources/application-test.yml
@@ -1,7 +1,8 @@
 spring:
   datasource:
-    url: jdbc:tc:postgresql:15-alpine:///his_db
-    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    url: jdbc:postgresql://localhost:5432/his_db
+    username: his_user
+    password: dev_password
   flyway:
     enabled: true
     locations: classpath:db/migration


### PR DESCRIPTION
## Summary
- Scope encounter entity tables to the `his_encounter` schema
- Qualify Flyway migrations for encounters and documentation with schema prefixes
- Simplify test profile to connect to the shared Postgres instance

## Testing
- `./mvnw -q test` *(fails: Network is unreachable for Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b6073578832488044a41c5e4cb6a